### PR TITLE
Update global gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.pyc
 *.temp
 *.cache
-.coverage
+.coverage*
 coverage.xml
 pytest.xml


### PR DESCRIPTION
Make `.coverage` ignores more generic in case `pytest` is run only on specific test or function

@Christof93 you would need to run `git pull && git rebase main` after this is merged in order to rebase your branch against the latest `main` branch head.