### PR TITLE
Patch all task unit tests

### DIFF
--- a/tests/tasks/test_datasets_random_split.py
+++ b/tests/tasks/test_datasets_random_split.py
@@ -60,7 +60,7 @@ def test_datasets_random_split(seed, expected):
     combined["test"] = train_test_dataset_dict["test"]
 
     # assert what is expected
-    assert set(range(25)) == set(
+    assert sorted(range(25)) == sorted(
         [index for _, data_split in combined.items() for index in data_split["text"]]
     )
     assert combined["train"]["text"] == expected["train"]

--- a/tests/tasks/test_opp_115.py
+++ b/tests/tasks/test_opp_115.py
@@ -12,7 +12,7 @@ def test_load_opp_115():
     )
 
     # check that all three splits are included
-    assert set(data.keys()) == {"train", "validation", "test"}
+    assert sorted(data.keys()) == sorted(["train", "validation", "test"])
 
     # iterate over splits
     for (split, data_split) in data.items():
@@ -20,21 +20,21 @@ def test_load_opp_115():
         assert data_split.column_names == ["text", "label"]
 
         # define what is expected from the load function
-        expected = set(
+        expected = sorted(
             [
                 (
                     f"{split} check for OPP-115",
-                    frozenset([f"label-{split}-1", f"label-{split}-2"]),
+                    sorted([f"label-{split}-1", f"label-{split}-2"]),
                 ),
                 (
                     f"another {split} check for OPP-115",
-                    frozenset([f"label-{split}-2"]),
+                    sorted([f"label-{split}-2"]),
                 ),
             ]
         )
 
         # assert that we got what is expected
         assert (
-            set(zip(data_split["text"], map(frozenset, data_split["label"])))
+            sorted(zip(data_split["text"], map(sorted, data_split["label"])))
             == expected
         )

--- a/tests/tasks/test_piextract.py
+++ b/tests/tasks/test_piextract.py
@@ -61,7 +61,7 @@ def test_read_conll_file():
     data = read_conll_file(conll_file)
 
     # check their keys make sense
-    assert set(data.keys()) == {"tokens", "ner_tags"}
+    assert sorted(data.keys()) == sorted(["tokens", "ner_tags"])
 
     # assert that we got what is expected
     assert data == mocked_conll_output()
@@ -105,7 +105,7 @@ def test_load_piextract_mocked(mocker):
     )
 
     # check that all three splits are included
-    assert set(data.keys()) == {"train", "validation", "test"}
+    assert sorted(data.keys()) == sorted(["train", "validation", "test"])
 
     # merge validation and train to train to compare against files
     data["train"] = datasets.concatenate_datasets([data["train"], data["validation"]])
@@ -117,12 +117,12 @@ def test_load_piextract_mocked(mocker):
         assert data_split.column_names == ["tokens", "ner_tags"]
 
         # assert that we got what is expected
-        assert set(
+        assert sorted(
             zip(
                 map(tuple, data_split["tokens"]),
                 [tuple(map(tuple, ner_tags)) for ner_tags in data_split["ner_tags"]],
             )
-        ) == set(
+        ) == sorted(
             zip(
                 map(tuple, mocked_conll_output()["tokens"]),
                 [
@@ -141,7 +141,7 @@ def test_load_piextract():
     )
 
     # check that all three splits are included
-    assert set(data.keys()) == {"train", "validation", "test"}
+    assert sorted(data.keys()) == sorted(["train", "validation", "test"])
 
     # merge validation and train to train to compare against files
     data["train"] = datasets.concatenate_datasets([data["train"], data["validation"]])
@@ -153,7 +153,7 @@ def test_load_piextract():
         assert data_split.column_names == ["tokens", "ner_tags"]
 
         # define what is expected from the load function
-        expected = set(
+        expected = sorted(
             [
                 (
                     (f"{split}", "check", "for", "PI-Extract"),
@@ -189,7 +189,7 @@ def test_load_piextract():
 
         # assert that we got what is expected
         assert (
-            set(
+            sorted(
                 zip(
                     map(tuple, data_split["tokens"]),
                     [

--- a/tests/tasks/test_policy_detection.py
+++ b/tests/tasks/test_policy_detection.py
@@ -15,7 +15,7 @@ def test_load_policy_detection():
     )
 
     # check that all three splits are included
-    assert set(data.keys()) == {"train", "validation", "test"}
+    assert sorted(data.keys()) == sorted(["train", "validation", "test"])
 
     # merge train and validation to train to compare against files
     data = datasets.concatenate_datasets(
@@ -23,7 +23,7 @@ def test_load_policy_detection():
     )
 
     # define what is expected from the load function
-    expected = set(
+    expected = sorted(
         [
             ("testing once", "Policy"),
             ("testing twice", "Not Policy"),
@@ -32,4 +32,4 @@ def test_load_policy_detection():
     )
 
     # assert that we got what is expected
-    assert set(zip(data["text"], data["label"])) == expected
+    assert sorted(zip(data["text"], data["label"])) == expected

--- a/tests/tasks/test_policy_ie_a.py
+++ b/tests/tasks/test_policy_ie_a.py
@@ -12,7 +12,7 @@ def test_load_policy_ie_a():
     )
 
     # check that all three splits are included
-    assert set(data.keys()) == {"train", "validation", "test"}
+    assert sorted(data.keys()) == sorted(["train", "validation", "test"])
 
     # iterate over splits
     for (split, data_split) in data.items():
@@ -20,7 +20,7 @@ def test_load_policy_ie_a():
         assert data_split.column_names == ["text", "label"]
 
         # define what is expected from the load function
-        expected = set(
+        expected = sorted(
             [
                 (
                     f"{split} check for PolicyIE-A",
@@ -34,4 +34,4 @@ def test_load_policy_ie_a():
         )
 
         # assert that we got what is expected
-        assert set(zip(data_split["text"], data_split["label"])) == expected
+        assert sorted(zip(data_split["text"], data_split["label"])) == expected

--- a/tests/tasks/test_policy_ie_b.py
+++ b/tests/tasks/test_policy_ie_b.py
@@ -12,7 +12,7 @@ def test_load_policy_ie_b():
     )
 
     # check that all three splits are included
-    assert set(data.keys()) == {"train", "validation", "test"}
+    assert sorted(data.keys()) == sorted(["train", "validation", "test"])
 
     # iterate over splits
     for (split, data_split) in data.items():
@@ -20,7 +20,7 @@ def test_load_policy_ie_b():
         assert data_split.column_names == ["tokens", "ner_tags"]
 
         # define what is expected from the load function
-        expected = set(
+        expected = sorted(
             [
                 (
                     (f"{split}", "check", "for", "PolicyIE-B"),
@@ -46,7 +46,7 @@ def test_load_policy_ie_b():
 
         # assert that we got what is expected
         assert (
-            set(
+            sorted(
                 zip(
                     map(tuple, data_split["tokens"]),
                     [

--- a/tests/tasks/test_policy_qa.py
+++ b/tests/tasks/test_policy_qa.py
@@ -12,7 +12,7 @@ def test_load_policy_qa():
     )
 
     # check that all three splits are included
-    assert set(data.keys()) == {"train", "test", "validation"}
+    assert sorted(data.keys()) == sorted(["train", "test", "validation"])
 
     # iterate over splits
     for (split, data_split) in data.items():
@@ -26,7 +26,7 @@ def test_load_policy_qa():
         ]
 
         # define what is expected from the load function
-        expected = set(
+        expected = sorted(
             [
                 (
                     "some_id",
@@ -49,7 +49,7 @@ def test_load_policy_qa():
 
         # assert that we got what is expected
         assert (
-            set(
+            sorted(
                 zip(
                     data_split["id"],
                     data_split["title"],

--- a/tests/tasks/test_privacy_qa.py
+++ b/tests/tasks/test_privacy_qa.py
@@ -13,7 +13,7 @@ def test_load_privacy_qa():
     )
 
     # check that all three splits are included
-    assert set(data.keys()) == {"train", "validation", "test"}
+    assert sorted(data.keys()) == sorted(["train", "validation", "test"])
 
     # merge train and validation to train to compare against files
     data["train"] = datasets.concatenate_datasets([data["train"], data["validation"]])
@@ -25,7 +25,7 @@ def test_load_privacy_qa():
         assert data_split.column_names == ["question", "text", "label"]
 
         # define what is expected from the load function
-        expected = set(
+        expected = sorted(
             [
                 (
                     f"{split} question for PrivacyQA?",
@@ -42,6 +42,6 @@ def test_load_privacy_qa():
 
         # assert that we got what is expected
         assert (
-            set(zip(data_split["question"], data_split["text"], data_split["label"]))
+            sorted(zip(data_split["question"], data_split["text"], data_split["label"]))
             == expected
         )


### PR DESCRIPTION
Migrate away from using `set` to `sorted` in order to compare actual and expected data. This has an advantage of not potentially removing duplicates while still being able to compare data.