### PR TITLE
Patch generic pipeline class

### DIFF
--- a/src/utils/pipeline_utils.py
+++ b/src/utils/pipeline_utils.py
@@ -75,29 +75,18 @@ class Privacy_GLUE_Pipeline(ABC):
         )
 
     def _init_third_party_loggers(self) -> None:
-        # configure datasets logger
-        # NOTE: if working with distributed training, logging/saving would only
-        # need to be configured on the main or zero process
+        # set logger verbosity
         datasets.utils.logging.set_verbosity(self.train_args.get_process_log_level())
-        add_file_handler(
-            datasets.utils.logging.get_logger(),
-            self.train_args.get_process_log_level(),
-            os.path.join(self.train_args.output_dir, "session.log"),
-        )
-
-        # configure transformers logger
-        # NOTE: if working with distributed training, logging/saving would only
-        # need to be configured on the main or zero process
         transformers.utils.logging.set_verbosity(
             self.train_args.get_process_log_level()
         )
-        transformers.utils.logging.enable_default_handler()
-        transformers.utils.logging.enable_explicit_format()
-        add_file_handler(
-            transformers.utils.logging.get_logger(),
-            self.train_args.get_process_log_level(),
-            os.path.join(self.train_args.output_dir, "session.log"),
-        )
+
+        # disable any default handlers since we take the root logger's
+        transformers.utils.logging.disable_default_handler()
+
+        # allow for propagation to the root logger to prevent double configurations
+        datasets.utils.logging.enable_propagation()
+        transformers.utils.logging.enable_propagation()
 
     def _check_for_success_file(self) -> None:
         # check for existing exit code and decide action


### PR DESCRIPTION
This PR does four major things related to the `Privacy_GLUE_Pipeline` class:

1. Add edge-case checks in `_clean_logger` method to ensure that logger exists before altering it
2. Add file handler removal calls to `_clean_logger` method
3. Rename `_clean_logger` method to `_clean_loggers` since this is more accurate
4. Simplify third-party logger configurations by enabling propagation and allowing root logger to handle everything