### PR TITLE
Update global gitignore for `wandb` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .coverage*
 coverage.xml
 pytest.xml
+wandb/


### PR DESCRIPTION
When running `wandb` in offline mode, a directory in the project root is created (called `wandb`). This PR updates the global gitignore to ignore this directory so that it is not accidentally committed to VCS.