### PR TITLE
Cb/wandb switch

### DIFF
--- a/src/utils/pipeline_utils.py
+++ b/src/utils/pipeline_utils.py
@@ -17,6 +17,7 @@ from utils.logging_utils import init_logger, add_file_handler
 import transformers
 import datasets
 import logging
+import wandb
 import torch
 import os
 
@@ -146,9 +147,7 @@ class Privacy_GLUE_Pipeline(ABC):
 
     def _init_wandb_run(self) -> None:
         if "wandb" in self.train_args.report_to:
-            import wandb
-
-            self.wandb_run = wandb.init(
+            wandb.init(
                 name=(
                     f"{self.model_args.wandb_group_id[11:]}"
                     f"_seed_{str(self.train_args.seed)}"
@@ -172,8 +171,8 @@ class Privacy_GLUE_Pipeline(ABC):
             self.logger.handlers = []
 
     def _close_wandb(self) -> None:
-        if "wandb" in self.train_args.report_to and hasattr(self, "wandb_run"):
-            self.wandb_run.finish()
+        if "wandb" in self.train_args.report_to and wandb.run is not None:
+            wandb.run.finish()
 
     def _destroy(self) -> None:
         # some variables are not freed automatically by pytorch and can quickly


### PR DESCRIPTION
Using global keyword for wandb_run because of this
```When wandb.init() is called from your training script an API call is made to create a run object on our servers. A new process is started to stream and collect metrics, thereby keeping all threads and logic out of your primary process. Your script runs normally and writes to local files, while the separate process streams them to our servers along with system metrics.```

Otherwise it fails..
