### PR TITLE
Move deep-copying to experiment manager

### DIFF
--- a/src/utils/experiment_utils.py
+++ b/src/utils/experiment_utils.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import warnings
+from copy import deepcopy
 from glob import glob
 
 import numpy as np
@@ -136,6 +137,12 @@ class Privacy_GLUE_Experiment_Manager:
                     f"seed_{seed}",
                 )
 
+                # create deep copy of arguments
+                # NOTE: this ensures no back-propagation of downsteam changes
+                data_args = deepcopy(self.data_args)
+                model_args = deepcopy(self.model_args)
+                train_args = deepcopy(self.train_args)
+
                 # branch into separate workflows depending on task type
                 if self.data_args.task in [
                     "opp_115",
@@ -144,15 +151,15 @@ class Privacy_GLUE_Experiment_Manager:
                     "privacy_qa",
                 ]:
                     Sequence_Classification_Pipeline(
-                        self.data_args, self.model_args, self.train_args
+                        data_args, model_args, train_args
                     ).run_pipeline()
                 elif self.data_args.task in ["piextract", "policy_ie_b"]:
                     Sequence_Tagging_Pipeline(
-                        self.data_args, self.model_args, self.train_args
+                        data_args, model_args, train_args
                     ).run_pipeline()
                 elif self.data_args.task == "policy_qa":  # pragma: no branch
                     Reading_Comprehension_Pipeline(
-                        self.data_args, self.model_args, self.train_args
+                        data_args, model_args, train_args
                     ).run_pipeline()
 
         # summarize PrivacyGLUE benchmark

--- a/src/utils/pipeline_utils.py
+++ b/src/utils/pipeline_utils.py
@@ -5,7 +5,6 @@ import logging
 import os
 import shutil
 from abc import ABC, abstractmethod
-from copy import deepcopy
 from functools import wraps
 from glob import glob
 
@@ -50,9 +49,9 @@ class Privacy_GLUE_Pipeline(ABC):
         train_args: TrainingArguments,
         success_file: str = ".success",
     ) -> None:
-        self.data_args = deepcopy(data_args)
-        self.model_args = deepcopy(model_args)
-        self.train_args = deepcopy(train_args)
+        self.data_args = data_args
+        self.model_args = model_args
+        self.train_args = train_args
         self.success_file = success_file
 
     def _get_data(self) -> DatasetDict:

--- a/tests/utils/test_experiment_utils.py
+++ b/tests/utils/test_experiment_utils.py
@@ -11,6 +11,21 @@ import pytest
 from utils.experiment_utils import Privacy_GLUE_Experiment_Manager
 
 
+class Mocked_Pipeline_Override:
+    def __init__(self, data_args, model_args, train_args):
+        self.data_args = data_args
+        self.model_args = model_args
+        self.train_args = train_args
+        self.data_args.test = "test"
+        self.data_args.max_answer_length = 1000
+        self.model_args.trial = "trial"
+        self.train_args.experiment = "experiment"
+        self.train_args.report_to = ["test"]
+
+    def run_pipeline(self):
+        pass
+
+
 @pytest.mark.parametrize(
     "model_name_or_path, model_dir_basename",
     [
@@ -335,3 +350,47 @@ def test_summarize(
 
     # make assertion
     assert benchmark_summary == expected_benchmark_summary
+
+
+@pytest.mark.parametrize(
+    "task",
+    [
+        "all",
+        "opp_115",
+        "policy_detection",
+        "policy_ie_a",
+        "privacy_qa",
+        "piextract",
+        "policy_ie_b",
+        "policy_qa",
+    ],
+)
+def test_deep_copy_arguments(task, mocked_arguments, mocker):
+    # create experiment manager
+    experiment_manager = Privacy_GLUE_Experiment_Manager(
+        *mocked_arguments(task=task, do_summarize=False, with_experiment_args=True)
+    )
+
+    # mock modules to always return pipeline override
+    mocker.patch(
+        "utils.experiment_utils.Sequence_Classification_Pipeline",
+        Mocked_Pipeline_Override,
+    )
+    mocker.patch(
+        "utils.experiment_utils.Sequence_Tagging_Pipeline",
+        Mocked_Pipeline_Override,
+    )
+    mocker.patch(
+        "utils.experiment_utils.Reading_Comprehension_Pipeline",
+        Mocked_Pipeline_Override,
+    )
+
+    # run relevant manager method
+    experiment_manager.run_experiments()
+
+    # make assertions
+    assert not hasattr(experiment_manager.data_args, "test")
+    assert not hasattr(experiment_manager.model_args, "trial")
+    assert not hasattr(experiment_manager.train_args, "experiment")
+    assert experiment_manager.train_args.report_to != ["test"]
+    assert experiment_manager.data_args.max_answer_length != 1000

--- a/tests/utils/test_pipeline_utils.py
+++ b/tests/utils/test_pipeline_utils.py
@@ -68,31 +68,11 @@ def test_main_process_first_only(local_rank, mocked_arguments, mocker):
     ],
 )
 def test__init__(task, mocked_arguments):
-    # instantiate mocked pipeline
-    data_args, model_args, train_args = mocked_arguments(task=task)
-    mocked_pipeline = Mocked_Pipeline(data_args, model_args, train_args)
-
-    # make some perturbations
-    mocked_pipeline.data_args.test = "test"
-    mocked_pipeline.data_args.max_answer_length = 1000
-    mocked_pipeline.model_args.trial = "trial"
-    mocked_pipeline.train_args.experiment = "experiment"
-
-    # make initial assertions
+    mocked_pipeline = Mocked_Pipeline(*mocked_arguments(task=task))
     assert mocked_pipeline.data_args.task == task
     assert mocked_pipeline.model_args.model_name_or_path == "bert-base-uncased"
     assert mocked_pipeline.train_args.report_to == []
     assert mocked_pipeline.success_file == ".success"
-
-    # make assertions regarding deep-copy
-    assert hasattr(mocked_pipeline.data_args, "test")
-    assert hasattr(mocked_pipeline.model_args, "trial")
-    assert hasattr(mocked_pipeline.train_args, "experiment")
-    assert not hasattr(data_args, "test")
-    assert not hasattr(model_args, "trial")
-    assert not hasattr(train_args, "experiment")
-    assert mocked_pipeline.data_args.max_answer_length == 1000
-    assert data_args.max_answer_length != 1000
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR moves deep copying to the experiment manager instead of the generic pipeline